### PR TITLE
Graceful close of the websocket connection

### DIFF
--- a/container/container_test.go
+++ b/container/container_test.go
@@ -636,6 +636,19 @@ var _ = Describe("container", func() {
 			Eventually(proc.(process.DotNetProcess).StreamOpen, "10s", "0.1s").Should(BeClosed())
 		})
 
+		It("closes the WebSocket connection with CloseNormalClosure when the close event is received", func(){
+			proc, err := container.Run(garden.ProcessSpec{}, garden.ProcessIO{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			websocket.WriteJSON(testServer.handlerWS, netContainer.ProcessStreamEvent{
+				MessageType: "close",
+			})
+
+			Eventually(proc.(process.DotNetProcess).StreamOpen, "10s", "0.1s").Should(BeClosed())
+			Eventually(testServer.closeError, "10s", "0.1s").ShouldNot(BeNil())
+			Expect(testServer.closeError.Code).To(Equal(websocket.CloseNormalClosure))
+		})
+
 		It("returns the close message as the exit code", func() {
 			proc, err := container.Run(garden.ProcessSpec{}, garden.ProcessIO{})
 			Expect(err).ShouldNot(HaveOccurred())

--- a/container/fake_websocket_server_test.go
+++ b/container/fake_websocket_server_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 type TestWebSocketServer struct {
-	Url       *url.URL
-	events    []container.ProcessStreamEvent
-	handlerWS *websocket.Conn
-	listener  *stoppableListener.StoppableListener
-	wg        sync.WaitGroup
-	router    *mux.Router
+	Url        *url.URL
+	events     []container.ProcessStreamEvent
+	handlerWS  *websocket.Conn
+	listener   *stoppableListener.StoppableListener
+	wg         sync.WaitGroup
+	router     *mux.Router
+	closeError *websocket.CloseError
 }
 
 var upgrader = websocket.Upgrader{
@@ -65,6 +66,9 @@ func (server *TestWebSocketServer) createWebSocketHandler(containerId string) {
 			var streamEvent container.ProcessStreamEvent
 			err := websocket.ReadJSON(ws, &streamEvent)
 			if err != nil {
+				if websocketError, ok := err.(*websocket.CloseError); ok {
+					server.closeError = websocketError
+				}
 				continue
 			}
 			server.events = append(server.events, streamEvent)


### PR DESCRIPTION
The defer func will send a close message though the websocket connection and then it will keep the connection open until the C# side will also call the Close method.

Ref: "Read is requored" 
http://www.gorillatoolkit.org/pkg/websocket

Issue:
https://www.pivotaltracker.com/n/projects/1156164