### PR TITLE
Fix null exception in OnReceiveError

### DIFF
--- a/Containerizer/Containerizer/Controllers/ContainerProcessHandler.cs
+++ b/Containerizer/Containerizer/Controllers/ContainerProcessHandler.cs
@@ -65,6 +65,7 @@ namespace Containerizer.Controllers
             runService.container = containerService.GetContainerByHandle(handle);
         }
 
+
         public override void OnClose(WebSocketCloseStatus? closeStatus, string closeStatusDescription)
         {
             logger.Info("ContainerProcessHandler.OnClose", new Dictionary<string, object> {{"closeStatus", closeStatus.ToString()}, {"closeStatusDescription", closeStatusDescription}});
@@ -88,7 +89,7 @@ namespace Containerizer.Controllers
                 }
             }
 
-            return null;
+            return Task.Delay(0);
         }
     }
 }

--- a/Containerizer/Containerizer/Controllers/ContainerProcessHandler.cs
+++ b/Containerizer/Containerizer/Controllers/ContainerProcessHandler.cs
@@ -73,7 +73,12 @@ namespace Containerizer.Controllers
 
         public override void OnReceiveError(Exception error)
         {
-            logger.Error("ContainerProcessHandler.OnReceiveError", new Dictionary<string, object> {{"message", error.Message}, {"stackTrace", error.StackTrace}});
+            if (error.Message.Contains("'CloseAsync' method has already been called")) 
+                return;
+            if (error.Message.Contains("he WebSocket is in an invalid state ('Closed') for this operation.")) 
+                return;
+
+            logger.Error("ContainerProcessHandler.OnReceiveError", new Dictionary<string, object> { { "message", error.Message }, { "stackTrace", error.StackTrace } });
         }
 
         public override Task OnMessageReceived(ArraySegment<byte> message, WebSocketMessageType type)


### PR DESCRIPTION
Owin expects a valid Task from OnMessageReceived:
https://github.com/bryceg/Owin.WebSocket/blob/b21692b35a2ea47628db3df874f0df0eb8c99115/src/Owin.WebSocket/WebSocketConnection.cs#L251

Calling close will make the "await mWebSocket.ReceiveMessage" from owin crash with an unexpected error that will bubble up in the log files.

Owin.Websockets will eventually close the connection at the end of the loop:
https://github.com/bryceg/Owin.WebSocket/blob/b21692b35a2ea47628db3df874f0df0eb8c99115/src/Owin.WebSocket/WebSocketConnection.cs#L284

Related to this PR:
https://github.com/cloudfoundry-incubator/garden-windows/pull/7

https://www.pivotaltracker.com/n/projects/1156164